### PR TITLE
fix: overwriting existing files when downloading

### DIFF
--- a/lib/miteru/cli.rb
+++ b/lib/miteru/cli.rb
@@ -18,26 +18,21 @@ module Miteru
 
         puts "#{website.url}: it might contain a phishing kit (#{website.zip_files.join(',')}).".colorize(:light_red)
         post_to_slack(message) if options[:post_to_slack] && valid_slack_setting?
-        begin
-          download_zip_files(website.url, website.zip_files, options[:download_to]) if options[:auto_download]
-        rescue DownloadError => e
-          puts e.to_s
-        end
+        download_zip_files(website.url, website.zip_files, options[:download_to]) if options[:auto_download]
       end
     end
 
     no_commands do
       def download_zip_files(url, zip_files, base_dir)
-        failed_urls = []
         zip_files.each do |path|
           target_url = "#{url}/#{path}"
           begin
-            Downloader.download target_url, base_dir
-          rescue Down::Error => _
-            failed_urls << target_url
+            destination = Downloader.download(target_url, base_dir)
+            puts "Download #{target_url} as #{destination}"
+          rescue Down::Error => e
+            puts "Failed to download: #{target_url} (#{e})"
           end
         end
-        raise DownloadError, "Failed to download: #{failed_urls}.join(',')" unless failed_urls.empty?
       end
 
       def valid_slack_setting?

--- a/lib/miteru/downloader.rb
+++ b/lib/miteru/downloader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "down"
-require "uri"
+require "securerandom"
 
 module Miteru
   class Downloader
@@ -11,17 +11,17 @@ module Miteru
       @base_dir = base_dir
     end
 
-    def filename
-      uri = URI.parse(url)
-      File.basename(uri.path)
+    def save_filename
+      "#{SecureRandom.alphanumeric}.zip"
     end
 
     def destination
-      @destination ||= "#{base_dir}/#{filename}"
+      @destination ||= "#{base_dir}/#{save_filename}"
     end
 
     def download
       Down.download(url, destination: destination)
+      destination
     end
 
     def self.download(url, base_dir = "/tmp")

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe Miteru::CLI do
 
   subject { Miteru::CLI.new }
   describe "#download_zip_files" do
-    it "should not raise any error" do
+    it "should download file(s)" do
       url = "http://#{host}:#{port}/has_kit"
-      zip_files = ["#{url}/test.zip"]
-      expect(File.exist?("#{base_dir}/test.zip")).to eq(false)
+      zip_files = ["test.zip"]
+
+      expect(Dir.glob("#{base_dir}/*.zip").empty?).to be(true)
       subject.download_zip_files(url, zip_files, @path)
-      expect(File.exist?("#{base_dir}/test.zip")).to eq(true)
+      expect(Dir.glob("#{base_dir}/*.zip").empty?).to be(false)
     end
   end
 end

--- a/spec/downloader_spec.rb
+++ b/spec/downloader_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Miteru::Downloader do
   subject { Miteru::Downloader }
   describe "#download" do
     it "should download a file" do
-      expect(File.exist?("#{base_dir}/test.zip")).to eq(false)
-      subject.download("http://#{host}:#{port}/has_kit/test.zip", @path)
-      expect(File.exist?("#{base_dir}/test.zip")).to eq(true)
+      expect(Dir.glob("#{base_dir}/*.zip").empty?).to be(true)
+      dst = subject.download("http://#{host}:#{port}/has_kit/test.zip", @path)
+      expect(File.exist?(dst)).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Use SecureRandom.alphanumeric as a download filename for avoiding conflict.