### PR TITLE
fix: add an error to catch

### DIFF
--- a/lib/miteru/website.rb
+++ b/lib/miteru/website.rb
@@ -54,11 +54,13 @@ module Miteru
     end
 
     def doc
-      @doc ||= [].tap do |out|
-        out << Oga.parse_html(response.body.to_s)
-               rescue LL::ParserError => _
-                 out << nil
-      end.first
+      @doc ||= parse_html(response.body.to_s)
+    end
+
+    def parse_html(html)
+      Oga.parse_html(html)
+    rescue ArgumentError, LL::ParserError => _
+      nil
     end
 
     def links


### PR DESCRIPTION
Add ArgumentError to #doc because it has a possibility to throw the error