### PR TITLE
fix: add an error to catch

### DIFF
--- a/lib/miteru/website.rb
+++ b/lib/miteru/website.rb
@@ -59,7 +59,7 @@ module Miteru
 
     def parse_html(html)
       Oga.parse_html(html)
-    rescue ArgumentError, LL::ParserError => _
+    rescue ArgumentError, Encoding::CompatibilityError, LL::ParserError => _
       nil
     end
 


### PR DESCRIPTION
Add Encoding::CompatibilityError to #doc because it has a possibility to throw the error