### PR TITLE
refactor: remove @path variable

### DIFF
--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Miteru::HTTPClient do
 
     it "downloads a file" do
       expect(Dir.glob("#{base_dir}/*.zip").empty?).to be(true)
-      dst = subject.download("#{base_url}/has_kit/test.zip", @path)
+      dst = subject.download("#{base_url}/has_kit/test.zip", base_dir)
       expect(File.exist?(dst)).to eq(true)
     end
   end

--- a/spec/support/shared_contexts/download_kits_context.rb
+++ b/spec/support/shared_contexts/download_kits_context.rb
@@ -3,14 +3,13 @@
 require "fileutils"
 
 RSpec.shared_context "download_kits" do
+  let(:base_dir) { File.expand_path("../../../tmp", __dir__) }
+
   before do
-    @path = File.expand_path("../../../tmp", __dir__)
-    FileUtils.mkdir_p(@path)
+    FileUtils.mkdir_p base_dir
   end
 
   after do
-    FileUtils.remove_dir(@path) if Dir.exist?(@path)
+    FileUtils.remove_dir(base_dir) if Dir.exist?(base_dir)
   end
-
-  let(:base_dir) { @path }
 end


### PR DESCRIPTION
Switch to use let(:base_dir) instead of @path