### PR TITLE
refactor: Feed class error handling

### DIFF
--- a/lib/miteru/feeds/ayashige.rb
+++ b/lib/miteru/feeds/ayashige.rb
@@ -20,7 +20,7 @@ module Miteru
             "http://#{domain}"
           ]
         end.flatten
-      rescue HTTPResponseError, JSON::ParserError => e
+      rescue HTTPResponseError, HTTP::Error, JSON::ParserError => e
         puts "Failed to load ayashige feed (#{e})"
         []
       end

--- a/lib/miteru/feeds/urlscan.rb
+++ b/lib/miteru/feeds/urlscan.rb
@@ -25,7 +25,7 @@ module Miteru
 
         res = JSON.parse(get(url))
         res["results"].map { |result| result.dig("task", "url") }
-      rescue HTTPResponseError, JSON::ParserError => e
+      rescue HTTPResponseError, HTTP::Error, JSON::ParserError => e
         puts "Failed to load urlscan.io feed (#{e})"
         []
       end


### PR DESCRIPTION
Change to catch HTTP::Error as an error during fetching a feed